### PR TITLE
--wait seems to fail with kubernetes < 1.7.0

### DIFF
--- a/helm/helm-functions.sh
+++ b/helm/helm-functions.sh
@@ -54,9 +54,9 @@ package_chart () {
 #
 release_chart () {
   if [ -z $4 ]; then
-    helm upgrade --install --namespace $1 --debug --wait $2 $3
+    helm upgrade --install --namespace $1 --debug $2 $3
   else
-    helm upgrade --install --namespace $1 --version $4 --debug --wait $2 $3
+    helm upgrade --install --namespace $1 --version $4 --debug $2 $3
   fi
 }
 


### PR DESCRIPTION
If you use `--wait` to do the deployment, it gets stuck more often than, specially while testing. It seems that upgrading kubernetes to 1.7.x fixes the problem (https://github.com/kubernetes/helm/issues/2426)